### PR TITLE
Add sample docker image info to helm chart values

### DIFF
--- a/fleet-telemetry/values.yaml
+++ b/fleet-telemetry/values.yaml
@@ -3,8 +3,8 @@ tlsSecret:
   tlsCrt: ""
   tlsKey: ""
 image:
-  repository:
-  tag:
+  repository: tesla/fleet-telemetry
+  tag: v0.0.1
 resources:
   limits:
     cpu: 250m


### PR DESCRIPTION
Docker tags are published here https://hub.docker.com/r/tesla/fleet-telemetry/tags