### PR TITLE
update default version for fleet telemetry in helm charts

### DIFF
--- a/charts/fleet-telemetry/README.md
+++ b/charts/fleet-telemetry/README.md
@@ -37,7 +37,7 @@ helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
 | `tlsSecret.tlsCrt`    | value of the certification                                                          | `nil`                   |
 | `tlsSecret.tlsKey`    | value of the encryption key                                                         | `nil`                   |
 | `image.repository`    | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
-| `image.tag`           | value of the docker image tag                                                       | `v0.0.3`                |
+| `image.tag`           | value of the docker image tag                                                       | `v0.2.0`                |
 | `resources`           | CPU/Memory resource requests/limits                                                 | {}                      |
 | `nodeSelector`        | Node labels for pod assignment                                                      | {}                      |
 | `tolerations`         | Toleration labels for pod assignment                                                | {}                      |

--- a/charts/fleet-telemetry/values.yaml
+++ b/charts/fleet-telemetry/values.yaml
@@ -5,7 +5,7 @@ tlsSecret:
   tlsKey: ""
 image:
   repository: tesla/fleet-telemetry
-  tag: v0.0.3
+  tag: v0.2.0
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
v0.2.0 fixes some memory leaks issues of fleet telemetry hence making it the default version