### PR TITLE
Bump minimum version for fleet telemetry

### DIFF
--- a/charts/fleet-telemetry/README.md
+++ b/charts/fleet-telemetry/README.md
@@ -37,7 +37,7 @@ helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
 | `tlsSecret.tlsCrt`    | value of the certification                                                          | `nil`                   |
 | `tlsSecret.tlsKey`    | value of the encryption key                                                         | `nil`                   |
 | `image.repository`    | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
-| `image.tag`           | value of the docker image tag                                                       | `v0.2.0`                |
+| `image.tag`           | value of the docker image tag                                                       | `v0.3.0`                |
 | `resources`           | CPU/Memory resource requests/limits                                                 | {}                      |
 | `nodeSelector`        | Node labels for pod assignment                                                      | {}                      |
 | `tolerations`         | Toleration labels for pod assignment                                                | {}                      |
@@ -69,7 +69,6 @@ config:
       "log_level": "info",
       "json_log_enable": true,
       "namespace": "tesla_telemetry",
-      "reliable_ack": false,
       "monitoring": {
         "prometheus_metrics_port": 9273,
         "profiler_port": 4269,
@@ -123,7 +122,6 @@ tlsSecret:
   "log_level": "info",
   "json_log_enable": true,
   "namespace": "tesla_telemetry",
-  "reliable_ack": false,
   "monitoring": {
     "prometheus_metrics_port": 9273,
     "profiler_port": 4269,

--- a/charts/fleet-telemetry/values.yaml
+++ b/charts/fleet-telemetry/values.yaml
@@ -5,7 +5,7 @@ tlsSecret:
   tlsKey: ""
 image:
   repository: tesla/fleet-telemetry
-  tag: v0.2.0
+  tag: v0.3.0
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
use 0.3.0 as default fleet telemetry version