### PR TITLE
Use latest tag in helm chart for fleet telemetry

### DIFF
--- a/charts/fleet-telemetry/README.md
+++ b/charts/fleet-telemetry/README.md
@@ -37,7 +37,7 @@ helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
 | `tlsSecret.tlsCrt`    | value of the certification                                                          | `nil`                   |
 | `tlsSecret.tlsKey`    | value of the encryption key                                                         | `nil`                   |
 | `image.repository`    | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
-| `image.tag`           | value of the docker image tag                                                       | `v0.3.0`                |
+| `image.tag`           | value of the docker image tag                                                       | `latest`                |
 | `resources`           | CPU/Memory resource requests/limits                                                 | {}                      |
 | `nodeSelector`        | Node labels for pod assignment                                                      | {}                      |
 | `tolerations`         | Toleration labels for pod assignment                                                | {}                      |

--- a/charts/fleet-telemetry/values.yaml
+++ b/charts/fleet-telemetry/values.yaml
@@ -5,7 +5,7 @@ tlsSecret:
   tlsKey: ""
 image:
   repository: tesla/fleet-telemetry
-  tag: v0.3.0
+  tag: latest
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
will merge after a fleet-telemetry image with `latest` tag is merged