### PR TITLE
tlsSecret.extraServerCerts property was added to be able to mount certs

### DIFF
--- a/charts/fleet-telemetry/README.md
+++ b/charts/fleet-telemetry/README.md
@@ -34,9 +34,9 @@ helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
 | Parameter                    | Description                                                                         | Default                 |
 |------------------------------|-------------------------------------------------------------------------------------|-------------------------|
 | `tlsSecret.name`             | Name of existing secret, if this value is set `tlsCrt` and `tlsKey` will be ignored | `nil`                   |
-| `tlsSecret.extraServerCerts` | If `name` is set, additional sources of certificates can be added                   | []                      |
 | `tlsSecret.tlsCrt`           | value of the certification                                                          | `nil`                   |
 | `tlsSecret.tlsKey`           | value of the encryption key                                                         | `nil`                   |
+| `tlsSecret.extraServerCerts` | Additional sources of certificates can be added                                     | []                      |
 | `image.repository`           | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
 | `image.tag`                  | value of the docker image tag                                                       | `latest`                |
 | `resources`                  | CPU/Memory resource requests/limits                                                 | {}                      |

--- a/charts/fleet-telemetry/README.md
+++ b/charts/fleet-telemetry/README.md
@@ -31,19 +31,20 @@ helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
 ```
 
 ## Configuration
-| Parameter             | Description                                                                         | Default                 |
-|-----------------------|-------------------------------------------------------------------------------------|-------------------------|
-| `tlsSecret.name`      | Name of existing secret, if this value is set `tlsCrt` and `tlsKey` will be ignored | `nil`                   |
-| `tlsSecret.tlsCrt`    | value of the certification                                                          | `nil`                   |
-| `tlsSecret.tlsKey`    | value of the encryption key                                                         | `nil`                   |
-| `image.repository`    | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
-| `image.tag`           | value of the docker image tag                                                       | `latest`                |
-| `resources`           | CPU/Memory resource requests/limits                                                 | {}                      |
-| `nodeSelector`        | Node labels for pod assignment                                                      | {}                      |
-| `tolerations`         | Toleration labels for pod assignment                                                | {}                      |
-| `replicas`            | Number of pods                                                                      | `1`                     |
-| `service.annotations` | Service Annotations                                                                 | {}                      |
-| `service.type`        | Service Type                                                                        | ClusterIP               |
+| Parameter                    | Description                                                                         | Default                 |
+|------------------------------|-------------------------------------------------------------------------------------|-------------------------|
+| `tlsSecret.name`             | Name of existing secret, if this value is set `tlsCrt` and `tlsKey` will be ignored | `nil`                   |
+| `tlsSecret.extraServerCerts` | If `name` is set, additional sources of certificates can be added                   | []                      |
+| `tlsSecret.tlsCrt`           | value of the certification                                                          | `nil`                   |
+| `tlsSecret.tlsKey`           | value of the encryption key                                                         | `nil`                   |
+| `image.repository`           | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
+| `image.tag`                  | value of the docker image tag                                                       | `latest`                |
+| `resources`                  | CPU/Memory resource requests/limits                                                 | {}                      |
+| `nodeSelector`               | Node labels for pod assignment                                                      | {}                      |
+| `tolerations`                | Toleration labels for pod assignment                                                | {}                      |
+| `replicas`                   | Number of pods                                                                      | `1`                     |
+| `service.annotations`        | Service Annotations                                                                 | {}                      |
+| `service.type`               | Service Type                                                                        | ClusterIP               |
 
 ## Example
 * Set `config.data` in `values.yaml`

--- a/charts/fleet-telemetry/templates/2-deployment.yaml
+++ b/charts/fleet-telemetry/templates/2-deployment.yaml
@@ -74,3 +74,8 @@ spec:
           sources:
           - secret:
               name: {{ .Values.tlsSecret.name | default (printf "%s" (include "fleet-telemetry.fullname" .)) }}
+          {{- if .Values.tlsSecret.name -}}
+          {{- if .Values.tlsSecret.extraServerCerts -}}
+          {{- toYaml .Values.tlsSecret.extraServerCerts | nindent 10 }}
+          {{- end -}}
+          {{- end -}}

--- a/charts/fleet-telemetry/templates/2-deployment.yaml
+++ b/charts/fleet-telemetry/templates/2-deployment.yaml
@@ -74,8 +74,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.tlsSecret.name | default (printf "%s" (include "fleet-telemetry.fullname" .)) }}
-          {{- if .Values.tlsSecret.name -}}
           {{- if .Values.tlsSecret.extraServerCerts -}}
           {{- toYaml .Values.tlsSecret.extraServerCerts | nindent 10 }}
-          {{- end -}}
           {{- end -}}

--- a/charts/fleet-telemetry/values.yaml
+++ b/charts/fleet-telemetry/values.yaml
@@ -1,5 +1,6 @@
 tlsSecret:
   name: ""
+  extraServerCerts: []
   create: false
   tlsCrt: ""
   tlsKey: ""

--- a/charts/fleet-telemetry/values.yaml
+++ b/charts/fleet-telemetry/values.yaml
@@ -1,9 +1,9 @@
 tlsSecret:
   name: ""
-  extraServerCerts: []
   create: false
   tlsCrt: ""
   tlsKey: ""
+  extraServerCerts: []
 image:
   repository: tesla/fleet-telemetry
   tag: latest


### PR DESCRIPTION
When using Kafka it would be nice to be able to include additional certs into /etc/certs/server directory.

This branch adds a `tlsSecret.extraServerCerts` property that allows adding additional sources of certs.

So if `values.yaml` is like below:
```
tlsSecret:
  name: "fleet-telemetry-secret"
  extraServerCerts:
    - secret:
        name: cluster-ca-cert
        items:
          - key: ca.crt
            path: ca.crt
    - secret:
        name: kafka-user
        items:
          - key: user.crt
            path: kafka.crt
          - key: user.key
            path: kafka.key
```

Then `2-deployment.yaml` will produce in `volumes:`

```
      - name: server-certs
        projected:
          sources:
          - secret:
              name: fleet-telemetry-secret
          - secret:
              items:
              - key: ca.crt
                path: ca.crt
              name: cluster-ca-cert
          - secret:
              items:
              - key: user.crt
                path: kafka.crt
              - key: user.key
                path: kafka.key
              name: kafka-user
```

This way, configs for fleet-telemetry can be sent to k8s like below:
```
    {
      "host": "0.0.0.0",
      "port": 443,
      ...
      "kafka": {
          "bootstrap.servers": "<bootstrap-url>",
          "security.protocol": "SSL",
          "ssl.ca.location": "/etc/certs/server/ca.crt",
          "ssl.certificate.location": "/etc/certs/server/kafka.crt",
          "ssl.key.location": "/etc/certs/server/kafka.key"
      },
      "tls": {
        "server_cert": "/etc/certs/server/tls.crt",
        "server_key": "/etc/certs/server/tls.key"
      }
    }
```