### PR TITLE
Bump app version and version to publish a new helm chart

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,17 +12,17 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
-          version: v3.11.2
+          version: v3.14.4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/fleet-telemetry/Chart.yaml
+++ b/charts/fleet-telemetry/Chart.yaml
@@ -13,11 +13,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.3"
+appVersion: "0.4.1"
 maintainers:
   - name: nathwang


### PR DESCRIPTION
Latest fleet telemetry version is 0.4.1
https://github.com/teslamotors/fleet-telemetry/releases/tag/v0.4.1
updating file to match that version